### PR TITLE
Add basic Node Express server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "socialtime_cda",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('Hello, world!');
+});
+
+app.get('/test', (req, res) => {
+  res.json({ message: 'This is a test route' });
+});
+
+app.get('/hello', (req, res) => {
+  const name = req.query.name || 'stranger';
+  res.json({ greeting: `Hello, ${name}!` });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- initialize Node project with `package.json`
- add `.gitignore`
- create `server.js` Express app with test routes

## Testing
- `npm install express` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68639909356c832e9510e1f5b2d7211d